### PR TITLE
Handle lifespan events correctly

### DIFF
--- a/starlette_opentracing/middleware.py
+++ b/starlette_opentracing/middleware.py
@@ -16,6 +16,7 @@ class StarletteTracingMiddleWare:
     async def __call__(self, scope, receive, send):
         # Skipping NON http and ASGI lifespan events
         if scope["type"] not in ["http", "websocket"]:
+            await self.app(scope, receive, send)
             return
 
         # Try to find and existing context in the provided request headers


### PR DESCRIPTION
Currently this middleware eats up application lifespan events so startup and shutdown handlers don't work, this fixes that