### PR TITLE
Adds option to use path templates for span operation name

### DIFF
--- a/starlette_opentracing/middleware.py
+++ b/starlette_opentracing/middleware.py
@@ -4,13 +4,29 @@ import opentracing
 from opentracing import InvalidCarrierException, SpanContextCorruptedException
 from opentracing.ext import tags
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
 
 
 class StarletteTracingMiddleWare(BaseHTTPMiddleware):
-    def __init__(self, app, tracer):
+    def __init__(self, app, tracer, use_template: bool = False):
         # Todo: add choice between global tracer and tracer that is already configured
         super().__init__(app)
         self._tracer = tracer
+        self.use_template = use_template
+
+    def get_template(self, request: Request) -> str:
+        """Get the template for the route endpoint."""
+        method = request.method
+        urls = [
+            route
+            for route in request.scope["router"].routes
+            if hasattr(route, "endpoint")
+            and "endpoint" in request.scope
+            and route.endpoint == request.scope["endpoint"]
+        ]
+        template = urls[0].path if len(urls) > 0 else "UNKNOWN"
+        method_path = method + " " + template
+        return method_path
 
     async def dispatch(self, request, call_next):
         span_ctx = None
@@ -38,4 +54,8 @@ class StarletteTracingMiddleWare(BaseHTTPMiddleware):
             span.set_tag(tags.HTTP_URL, url)
 
             response = await call_next(request)
+
+            if self.use_template:
+                operation_name = self.get_template(request)
+                span.set_operation_name(operation_name)
         return response

--- a/starlette_opentracing/middleware.py
+++ b/starlette_opentracing/middleware.py
@@ -17,13 +17,15 @@ class StarletteTracingMiddleWare(BaseHTTPMiddleware):
     def get_template(self, request: Request) -> str:
         """Get the template for the route endpoint."""
         method = request.method
-        urls = [
-            route
-            for route in request.scope["router"].routes
-            if hasattr(route, "endpoint") and
-            "endpoint" in request.scope and
-            route.endpoint == request.scope["endpoint"]
-        ]
+        if "endpoint" in request.scope:
+            urls = [
+                route
+                for route in request.scope["router"].routes
+                if hasattr(route, "endpoint") and route.endpoint == request.scope["endpoint"]
+            ]
+        else:
+            urls = []
+
         template = urls[0].path if len(urls) > 0 else "UNKNOWN"
         method_path = method + " " + template
         return method_path

--- a/starlette_opentracing/middleware.py
+++ b/starlette_opentracing/middleware.py
@@ -20,9 +20,9 @@ class StarletteTracingMiddleWare(BaseHTTPMiddleware):
         urls = [
             route
             for route in request.scope["router"].routes
-            if hasattr(route, "endpoint")
-            and "endpoint" in request.scope
-            and route.endpoint == request.scope["endpoint"]
+            if hasattr(route, "endpoint") and
+            "endpoint" in request.scope and
+            route.endpoint == request.scope["endpoint"]
         ]
         template = urls[0].path if len(urls) > 0 else "UNKNOWN"
         method_path = method + " " + template

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -72,5 +72,4 @@ def test_tracer_uses_path_templates_for_operation_names():
     client.get("/foo/MyFoo")
     spans = mocked_tracer.finished_spans()
     assert len(spans) == 1
-    urls = [span.tags.get("http.url") for span in spans]
     assert spans[0].operation_name == "GET /foo/{foo_id}"

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -73,3 +73,21 @@ def test_tracer_uses_path_templates_for_operation_names():
     spans = mocked_tracer.finished_spans()
     assert len(spans) == 1
     assert spans[0].operation_name == "GET /foo/{foo_id}"
+
+
+def test_tracer_uses_set_template_to_unknown_if_no_endpoint():
+    app = Starlette()
+    mocked_tracer = MockTracer(scope_manager=ContextVarsScopeManager())
+    app.add_middleware(
+        StarletteTracingMiddleWare, tracer=mocked_tracer, use_template=True
+    )
+
+    @app.route("/foo/{foo_id}")
+    def foo(foo_id: str):
+        return PlainTextResponse(f"Foo: {foo_id}")
+
+    client = TestClient(app)
+    client.get("/bar/MyFoo")
+    spans = mocked_tracer.finished_spans()
+    assert len(spans) == 1
+    assert spans[0].operation_name == "GET UNKNOWN"


### PR DESCRIPTION
When tracing endpoint that have a path parameter, especially when the path parameter is a unique id for a resource, the number of operations when viewing traces becomes very large. Using the path templates sets a finite limit of possible operation names.